### PR TITLE
Use output suffix in StringBuffer method name

### DIFF
--- a/src/components/Snippet/OutputSnippet/StringSnippetBlock/StringBufferSnippet/StringBufferSnippet.tsx
+++ b/src/components/Snippet/OutputSnippet/StringSnippetBlock/StringBufferSnippet/StringBufferSnippet.tsx
@@ -11,7 +11,7 @@ export interface StringBufferSnippetProps {
 export default class StringBufferSnippet extends Component<StringBufferSnippetProps> {
     public render(): ReactNode {
         const { controlIdentifier, output } = this.props;
-        const methodName = Snippet.snakeToCamelCase(`${controlIdentifier}_Buffer`);
+        const methodName = Snippet.snakeToCamelCase(`${controlIdentifier}${output.suffix}_Buffer`);
         const callbackMethodName = Snippet.snakeToCamelCase(`on_${controlIdentifier}_change`);
 
         return (


### PR DESCRIPTION
The original bios uses the output suffix for string buffers to differ the method name in places where the control has both an integer and string output.