### PR TITLE
Remove RESOLUTION/STEPS from AnalogMultiPosSnippet

### DIFF
--- a/src/components/Snippet/InputSnippet/SetStateSnippetBlock/AnalogMultiPosSnippet/AnalogMultiPosSnippet.tsx
+++ b/src/components/Snippet/InputSnippet/SetStateSnippetBlock/AnalogMultiPosSnippet/AnalogMultiPosSnippet.tsx
@@ -15,7 +15,7 @@ export default class AnalogMultiPosSnippet extends Component<AnalogMultiPosSnipp
         return (
             <Snippet>
                 DcsBios::AnalogMultiPos {methodName}({`"${controlIdentifier}"`}, <Variable>PIN</Variable>,{' '}
-                <Variable>STEPS</Variable>, <Variable>(RESOLUTION/STEPS)</Variable>);
+                <Variable>STEPS</Variable>);
             </Snippet>
         );
     }


### PR DESCRIPTION
This parameter is no longer in the bios ardiuno library